### PR TITLE
Switch to yarn for dependency management and update `check_connection` method

### DIFF
--- a/airbyte-integrations/connectors/source-tweag-blog/source_tweag_blog/source.py
+++ b/airbyte-integrations/connectors/source-tweag-blog/source_tweag_blog/source.py
@@ -220,7 +220,7 @@ class SourceTweagBlog(AbstractSource):
             gatsby_process.kill()
         self.free_port(12123)
 
-    def check_connection(self) -> Tuple[bool, any]:
+    def check_connection(self, logger, config) -> Tuple[bool, any]:
         """Check if the source is reachable"""
         return True, None
 

--- a/airbyte-integrations/connectors/source-tweag-blog/source_tweag_blog/source.py
+++ b/airbyte-integrations/connectors/source-tweag-blog/source_tweag_blog/source.py
@@ -181,8 +181,9 @@ class SourceTweagBlog(AbstractSource):
         """Start the Gatsby server"""
         if not os.path.exists(os.path.join(repo_dir, "node_modules", ".bin", "gatsby")):
             logger.info("Installing npm dependencies")
+            subprocess.Popen(["npm", "install", "--global", "yarn"], cwd=repo_dir).wait()
             subprocess.Popen(
-                ["npm", "install", "--legacy-peer-deps"],
+                ["yarn", "install"],
                 cwd=repo_dir,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
This PR introduces the following changes to streamline the setup process and fix the connection check:

- Switched to Yarn for dependency installation:
Replaced `npm install --legacy-peer-deps` with `yarn install` for smoother dependency management.
- Updated `check_connection` method:
Modified the `check_connection` function to include logger and config as parameters, ensuring proper logging and configuration handling during the connection check. Otherwise the `check_connection` will fail.